### PR TITLE
v0.3.0

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -9,7 +9,7 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Parameters.yml@cov
     with:
       name: sphinx-eports
-#      python_version_list: "3.8 3.9 3.10 3.11 3.12 pypy-3.8 pypy-3.9 pypy-3.10"
+      python_version_list: "3.9 3.10 3.11 3.12 pypy-3.9 pypy-3.10"
 #      disable_list: "windows:pypy-3.8 windows:pypy-3.9 windows:pypy-3.10"
 
   UnitTesting:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Each report directive might require an individual configuration, therefore see t
 
 ## Documentation Coverage
 
-    DocCov: write introduction
+```
+DocCov: write introduction
+```
 
 
 ### Quick Configuration
@@ -61,7 +63,7 @@ details.
    directive. Here, the ID is called `src` (dictionary key). Each package needs 4 configuration entries:
 
    * `name`  
-     Name of the Python package[^PkgNameVsPkgDir].
+     Name of the Python package[^1].
    * `directory`  
      The directory of the package to analyze.
    * `fail_below`  
@@ -100,20 +102,29 @@ details.
       :packageid: src
    ```
 
+[^1]: Toplevel Python packages can reside in a directory not matching the package name. This is possible because the
+      toplevel package name is set in the package installation description. This is not good practice, but possible and
+      unfortunately widely used. E.g. `src` as directory name.
 
 ## Code Coverage
 
-    CodeCov: write introduction
+```
+CodeCov: write introduction
+```
 
 
 ## Unit Test Summary
 
-    UnitTest: write introduction
+```
+UnitTest: write introduction
+```
 
 
 ## Dependencies
 
-    Dep: write introduction
+```
+Dep: write introduction
+```
 
 
 ## Contributors

--- a/doc/Examples/FullyDocumented.rst
+++ b/doc/Examples/FullyDocumented.rst
@@ -1,0 +1,7 @@
+Fully Undocumented
+##################
+
+The following report shows a fully documented package.
+
+.. report:doc-coverage::
+   :packageid: documented

--- a/doc/Examples/PartiallyDocumented.rst
+++ b/doc/Examples/PartiallyDocumented.rst
@@ -1,0 +1,7 @@
+Partially Documented
+####################
+
+The following report shows a partially documented package.
+
+.. report:doc-coverage::
+   :packageid: partially

--- a/doc/Examples/Undocumented.rst
+++ b/doc/Examples/Undocumented.rst
@@ -1,0 +1,7 @@
+Undocumented
+############
+
+The following report shows an undocumented package.
+
+.. report:doc-coverage::
+   :packageid: undocumented

--- a/doc/Glossary.rst
+++ b/doc/Glossary.rst
@@ -9,10 +9,22 @@ Glossary
    Code Coverage
      tbd
 
-   Documentation Coverage
+   doc-string
      tbd
 
-   Python doc-string
+     .. code-block:: Python
+
+        def myFunction(a: int, b: int) -> str:
+          """
+          Converts 2 integers to a tuple represented as a string.
+
+          :param a: First tuple element.
+          :param b: Second tuple element.
+          :returns: The tuple ``"(a, b)"`` as a string.
+          """
+          return f"({a}, {b})"
+
+   Documentation Coverage
      tbd
 
    Statement Coverage

--- a/doc/_static/css/override.css
+++ b/doc/_static/css/override.css
@@ -99,27 +99,3 @@ section > p,
 	padding-left: 0;
 	padding-right: 0;
 }
-
-.rst-content table.docutils:not(.field-list) tr:nth-child(2n-1) td {
-	background-color: unset;
-}
-
-.doccov-below100 {
-	background: rgba(0, 200, 82, .4);
-}
-.doccov-below90 {
-	background: rgba(0, 200, 82, .2);
-}
-.doccov-below80 {
-	background: rgba(255, 145, 0, .2);
-}
-.doccov-below50 {
-	background: rgba(255, 82, 82, .2);
-}
-.doccov-below30 {
-	background: rgba(101, 31, 255, .2);
-}
-
-.doccov-summary-row {
-	font-weight: bold;
-}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -261,18 +261,38 @@ todo_link_only = True
 # ==============================================================================
 # Sphinx-reports - DocCov
 # ==============================================================================
+_levels = {
+	30:  {"class": "doccov-below30",  "desc": "almost undocumented"},
+	50:  {"class": "doccov-below50",  "desc": "poorly documented"},
+	80:  {"class": "doccov-below80",  "desc": "roughly documented"},
+	90:  {"class": "doccov-below90",  "desc": "well documented"},
+	100: {"class": "doccov-below100", "desc": "excellent documented"}
+}
+
 report_doccov_packages = {
 	"src": {
 		"name":       "sphinx_reports",
 		"directory":  "../sphinx_reports",
 		"fail_below": 80,
-		"levels": {
-			30:  {"class": "doccov-below30",  "background": "rgba(101,  31, 255, .2)", "desc": "almost undocumented"},
-			50:  {"class": "doccov-below50",  "background": "rgba(255,  82,  82, .2)", "desc": "poorly documented"},
-			80:  {"class": "doccov-below80",  "background": "rgba(255, 145,   0, .2)", "desc": "roughly documented"},
-			90:  {"class": "doccov-below90",  "background": "rgba(  0, 200,  82, .2)", "desc": "well documented"},
-			100: {"class": "doccov-below100", "background": "rgba(  0, 200,  82, .2)", "desc": "excellent documented"}
-		}
+		"levels":     _levels
+	},
+	"undocumented": {
+		"name":       "undocumented",
+		"directory":  "../tests/packages/undocumented",
+		"fail_below": 80,
+		"levels":     _levels
+	},
+	"partially": {
+		"name":       "partially",
+		"directory":  "../tests/packages/partially",
+		"fail_below": 80,
+		"levels":     _levels
+	},
+	"documented": {
+		"name":       "documented",
+		"directory":  "../tests/packages/documented",
+		"fail_below": 80,
+		"levels":     _levels
 	}
 }
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -152,7 +152,9 @@ License
    :caption: Examples
    :hidden:
 
-
+   Examples/Undocumented
+   Examples/PartiallyDocumented
+   Examples/FullyDocumented
 
 .. toctree::
    :caption: Supported Reports

--- a/run.ps1
+++ b/run.ps1
@@ -97,7 +97,7 @@ if ($install)
   { Write-Host -ForegroundColor Cyan     "[ADMIN][UNINSTALL] Uninstalling $PackageName ..."
     py -3.12 -m pip uninstall -y $PackageName
     Write-Host -ForegroundColor Cyan     "[ADMIN][INSTALL]   Installing $PackageName from wheel ..."
-    py -3.12 -m pip install .\dist\$PackageName-0.2.0-py3-none-any.whl
+    py -3.12 -m pip install .\dist\$PackageName-0.3.0-py3-none-any.whl
 
     Write-Host -ForegroundColor Cyan     "[ADMIN][INSTALL]   Closing window in 5 seconds ..."
     Start-Sleep -Seconds 5

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@
 #
 """Package installer for 'Write version information for any programming language as source file'."""
 from pathlib             import Path
-from pyTooling.Packaging import DescribePythonPackageHostedOnGitHub
+from pyTooling.Packaging import DescribePythonPackageHostedOnGitHub, DEFAULT_CLASSIFIERS
 
 gitHubNamespace =        "pyTooling"
 packageName =            "sphinx_reports"
@@ -42,6 +42,15 @@ DescribePythonPackageHostedOnGitHub(
 	description="A Sphinx extension providing coverage details embedded in documentation pages.",
 	gitHubNamespace=gitHubNamespace,
 	sourceFileWithVersion=packageInformationFile,
+	classifiers=DEFAULT_CLASSIFIERS + [
+		"Framework :: Sphinx",
+		"Framework :: Sphinx :: Domain",
+		"Framework :: Sphinx :: Extension",
+		"Topic :: Documentation :: Sphinx",
+		"Topic :: Software Development :: Documentation",
+		"Topic :: Software Development :: Quality Assurance",
+	],
+	developmentStatus="beta",
 	dataFiles={
 		"sphinx_reports": ["static/*.css"]
 	}

--- a/sphinx_reports/Adapter/DocStrCoverage.py
+++ b/sphinx_reports/Adapter/DocStrCoverage.py
@@ -82,7 +82,7 @@ class Analyzer:
 		return self._coverageReport
 
 	def Analyze(self) -> ResultCollection:
-		self._coverageReport: ResultCollection = analyze(self._moduleFiles)
+		self._coverageReport: ResultCollection = analyze(self._moduleFiles, show_progress=False)
 		return self._coverageReport
 
 	def Convert(self) -> PackageCoverage:
@@ -93,10 +93,10 @@ class Analyzer:
 			perFileResult: FileCount = value.count_aggregate()
 
 			moduleName = path.stem
-			modulePath = [p.name for p in path.parents]
+			modulePath = [p.name for p in path.parents if p.name != ""]
 
 			currentCoverageObject: AggregatedCoverage = rootPackageCoverage
-			for packageName in modulePath[1:]:
+			for packageName in modulePath:
 				try:
 					currentCoverageObject = currentCoverageObject[packageName]
 				except KeyError:

--- a/sphinx_reports/Adapter/DocStrCoverage.py
+++ b/sphinx_reports/Adapter/DocStrCoverage.py
@@ -39,7 +39,7 @@ from docstr_coverage.result_collection import FileCount
 from pyTooling.Decorators              import export, readonly
 
 from sphinx_reports.Common                          import ReportExtensionError
-from sphinx_reports.DataModel.DocumentationCoverage import ModuleCoverage, PackageCoverage
+from sphinx_reports.DataModel.DocumentationCoverage import ModuleCoverage, PackageCoverage, AggregatedCoverage
 
 
 @export
@@ -54,7 +54,7 @@ class Analyzer:
 	_moduleFiles:     List[Path]
 	_coverageReport:  str
 
-	def __init__(self, directory: Path, packageName: str):
+	def __init__(self, directory: Path, packageName: str) -> None:
 		self._searchDirectory = directory
 		self._packageName = packageName
 		self._moduleFiles = []
@@ -95,7 +95,7 @@ class Analyzer:
 			moduleName = path.stem
 			modulePath = [p.name for p in path.parents]
 
-			currentCoverageObject = rootPackageCoverage
+			currentCoverageObject: AggregatedCoverage = rootPackageCoverage
 			for packageName in modulePath[1:]:
 				try:
 					currentCoverageObject = currentCoverageObject[packageName]

--- a/sphinx_reports/Adapter/DocStrCoverage.py
+++ b/sphinx_reports/Adapter/DocStrCoverage.py
@@ -32,7 +32,6 @@
 **A Sphinx extension providing coverage details embedded in documentation pages.**
 """
 from pathlib import Path
-from sys     import version_info
 from typing  import List
 
 from docstr_coverage                   import analyze, ResultCollection
@@ -45,15 +44,7 @@ from sphinx_reports.DataModel.DocumentationCoverage import ModuleCoverage, Packa
 
 @export
 class DocStrCoverageError(ReportExtensionError):
-	# WORKAROUND: for Python <3.11
-	# Implementing a dummy method for Python versions before
-	__notes__: List[str]
-	if version_info < (3, 11):  # pragma: no cover
-		def add_note(self, message: str):
-			try:
-				self.__notes__.append(message)
-			except AttributeError:
-				self.__notes__ = [message]
+	pass
 
 
 @export

--- a/sphinx_reports/CodeCoverage.py
+++ b/sphinx_reports/CodeCoverage.py
@@ -159,7 +159,7 @@ class CodeCoverage(BaseDirective):
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Expected}")),
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Covered}")),
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Uncovered}")),
-				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Coverage:.0%}")),
+				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Coverage:.1%}")),
 				classes=["doccov-table-row", self._ConvertToColor(packageCoverage.Coverage, "class")],
 				# style="background: rgba(  0, 200,  82, .2);"
 			)
@@ -174,7 +174,7 @@ class CodeCoverage(BaseDirective):
 					nodes.entry("", nodes.paragraph(text=f"{module.Expected}")),
 					nodes.entry("", nodes.paragraph(text=f"{module.Covered}")),
 					nodes.entry("", nodes.paragraph(text=f"{module.Uncovered}")),
-					nodes.entry("", nodes.paragraph(text=f"{module.Coverage :.0%}")),
+					nodes.entry("", nodes.paragraph(text=f"{module.Coverage :.1%}")),
 					classes=["doccov-table-row", self._ConvertToColor(module.Coverage, "class")],
 					# style="background: rgba(  0, 200,  82, .2);"
 				)
@@ -188,7 +188,7 @@ class CodeCoverage(BaseDirective):
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Expected}")),
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Covered}")),
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Uncovered}")),
-			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Coverage:.0%}"),
+			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Coverage:.1%}"),
 				# classes=[self._ConvertToColor(self._coverage.coverage(), "class")]
 			),
 			classes=["doccov-summary-row", self._ConvertToColor(self._coverage.AggregatedCoverage, "class")]

--- a/sphinx_reports/CodeCoverage.py
+++ b/sphinx_reports/CodeCoverage.py
@@ -159,7 +159,7 @@ class CodeCoverage(BaseDirective):
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Expected}")),
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Covered}")),
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Uncovered}")),
-				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Coverage:.1%}")),
+				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Coverage:.0%}")),
 				classes=["doccov-table-row", self._ConvertToColor(packageCoverage.Coverage, "class")],
 				# style="background: rgba(  0, 200,  82, .2);"
 			)
@@ -174,7 +174,7 @@ class CodeCoverage(BaseDirective):
 					nodes.entry("", nodes.paragraph(text=f"{module.Expected}")),
 					nodes.entry("", nodes.paragraph(text=f"{module.Covered}")),
 					nodes.entry("", nodes.paragraph(text=f"{module.Uncovered}")),
-					nodes.entry("", nodes.paragraph(text=f"{module.Coverage :.1%}")),
+					nodes.entry("", nodes.paragraph(text=f"{module.Coverage :.0%}")),
 					classes=["doccov-table-row", self._ConvertToColor(module.Coverage, "class")],
 					# style="background: rgba(  0, 200,  82, .2);"
 				)
@@ -188,7 +188,7 @@ class CodeCoverage(BaseDirective):
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Expected}")),
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Covered}")),
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Uncovered}")),
-			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Coverage:.1%}"),
+			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Coverage:.0%}"),
 				# classes=[self._ConvertToColor(self._coverage.coverage(), "class")]
 			),
 			classes=["doccov-summary-row", self._ConvertToColor(self._coverage.AggregatedCoverage, "class")]

--- a/sphinx_reports/CodeCoverage.py
+++ b/sphinx_reports/CodeCoverage.py
@@ -122,13 +122,13 @@ class CodeCoverage(BaseDirective):
 		for levelLimit, levelConfig in self._levels.items():
 			if (currentLevel * 100) < levelLimit:
 				return levelConfig[configKey]
-		else:
-			return self._levels[100][configKey]
+
+		return self._levels[100][configKey]
 
 	def _GenerateCoverageTable(self) -> nodes.table:
 		# Create a table and table header with 5 columns
 		table, tableGroup = self._PrepareTable(
-			id=self._packageID,
+			identifier=self._packageID,
 			columns={
 				"Filename": 500,
 				"Total": 100,
@@ -189,10 +189,10 @@ class CodeCoverage(BaseDirective):
 
 		return table
 
-	def _CreateLegend(self, id: str, classes: Iterable[str]) -> List[nodes.Element]:
+	def _CreateLegend(self, identifier: str, classes: Iterable[str]) -> List[nodes.Element]:
 		rubric = nodes.rubric("", text="Legend")
 
-		table = nodes.table("", id=id, classes=classes)
+		table = nodes.table("", id=identifier, classes=classes)
 
 		tableGroup = nodes.tgroup(cols=2)
 		table += tableGroup
@@ -231,11 +231,11 @@ class CodeCoverage(BaseDirective):
 		container = nodes.container()
 
 		if LegendPosition.Top in self._legend:
-			container += self._CreateLegend(id="legend1", classes=["doccov-legend"])
+			container += self._CreateLegend(identifier="legend1", classes=["doccov-legend"])
 
 		container += self._GenerateCoverageTable()
 
 		if LegendPosition.Bottom in self._legend:
-			container += self._CreateLegend(id="legend2", classes=["doccov-legend"])
+			container += self._CreateLegend(identifier="legend2", classes=["doccov-legend"])
 
 		return [container]

--- a/sphinx_reports/Common.py
+++ b/sphinx_reports/Common.py
@@ -31,12 +31,14 @@
 """
 **Common exceptions, classes and helper functions..**
 """
-from enum   import Flag
-from sys    import version_info
-from typing import List
+from enum                        import Flag
+from importlib.resources         import files
+from sys                         import version_info
+from types                       import ModuleType
+from typing                      import List, Union
 
-from pyTooling.Decorators import export
-from sphinx.errors        import ExtensionError
+from pyTooling.Decorators        import export
+from sphinx.errors               import ExtensionError
 
 
 @export
@@ -58,3 +60,8 @@ class LegendPosition(Flag):
 	Top = 1
 	Bottom = 2
 	Both = 3
+
+
+@export
+def ReadResourceFile(module: Union[str, ModuleType], filename: str) -> str:
+	return files(module).joinpath(filename).read_text()

--- a/sphinx_reports/Common.py
+++ b/sphinx_reports/Common.py
@@ -45,7 +45,7 @@ class ReportExtensionError(ExtensionError):
 	# Implementing a dummy method for Python versions before
 	__notes__: List[str]
 	if version_info < (3, 11):  # pragma: no cover
-		def add_note(self, message: str):
+		def add_note(self, message: str) -> None:
 			try:
 				self.__notes__.append(message)
 			except AttributeError:

--- a/sphinx_reports/DataModel/DocumentationCoverage.py
+++ b/sphinx_reports/DataModel/DocumentationCoverage.py
@@ -244,6 +244,9 @@ class ClassCoverage(Coverage):
 
 		super().CalculateCoverage()
 
+	def __str__(self) -> str:
+		return f"<ClassCoverage - tot:{self._total}, ex:{self._excluded}, ig:{self._ignored}, exp:{self._expected}, cov:{self._covered}, un:{self._uncovered} => {self._coverage:.1%}>"
+
 
 @export
 class ModuleCoverage(AggregatedCoverage):
@@ -304,6 +307,9 @@ class ModuleCoverage(AggregatedCoverage):
 			self._aggregatedUncovered += cls._uncovered
 
 		super().Aggregate()
+
+	def __str__(self) -> str:
+		return f"<ModuleCoverage - tot:{self._total}|{self._aggregatedTotal}, ex:{self._excluded}|{self._aggregatedExcluded}, ig:{self._ignored}|{self._aggregatedIgnored}, exp:{self._expected}|{self._aggregatedExpected}, cov:{self._covered}|{self._aggregatedCovered}, un:{self._uncovered}|{self._aggregatedUncovered} => {self._coverage:.1%}|{self._aggregatedCoverage:.1%}>"
 
 
 @export
@@ -407,3 +413,6 @@ class PackageCoverage(AggregatedCoverage):
 			self._aggregatedUncovered += mod._uncovered
 
 		super().Aggregate()
+
+	def __str__(self) -> str:
+		return f"<PackageCoverage - tot:{self._total}|{self._aggregatedTotal}, ex:{self._excluded}|{self._aggregatedExcluded}, ig:{self._ignored}|{self._aggregatedIgnored}, exp:{self._expected}|{self._aggregatedExpected}, cov:{self._covered}|{self._aggregatedCovered}, un:{self._uncovered}|{self._aggregatedUncovered} => {self._coverage:.1%}|{self._aggregatedCoverage:.1%}>"

--- a/sphinx_reports/DataModel/DocumentationCoverage.py
+++ b/sphinx_reports/DataModel/DocumentationCoverage.py
@@ -220,6 +220,18 @@ class ClassCoverage(Coverage):
 		self._methods = {}
 		self._classes = {}
 
+	@readonly
+	def Fields(self) -> Dict[str, CoverageState]:
+		return self._fields
+
+	@readonly
+	def Methods(self) -> Dict[str, CoverageState]:
+		return self._methods
+
+	@readonly
+	def Classes(self) -> Dict[str, "ClassCoverage"]:
+		return self._classes
+
 	def CalculateCoverage(self) -> None:
 		for cls in self._classes.values():
 			cls.CalculateCoverage()
@@ -250,6 +262,18 @@ class ModuleCoverage(AggregatedCoverage):
 		self._variables = {}
 		self._functions = {}
 		self._classes =   {}
+
+	@readonly
+	def Variables(self) -> Dict[str, CoverageState]:
+		return self._variables
+
+	@readonly
+	def Functions(self) -> Dict[str, CoverageState]:
+		return self._functions
+
+	@readonly
+	def Classes(self) -> Dict[str, ClassCoverage]:
+		return self._classes
 
 	def CalculateCoverage(self) -> None:
 		for cls in self._classes.values():
@@ -308,6 +332,27 @@ class PackageCoverage(AggregatedCoverage):
 	@readonly
 	def FileCount(self) -> int:
 		return self._fileCount
+
+	@readonly
+	def Variables(self) -> Dict[str, CoverageState]:
+		return self._variables
+
+
+	@readonly
+	def Functions(self) -> Dict[str, CoverageState]:
+		return self._functions
+
+	@readonly
+	def Classes(self) -> Dict[str, ClassCoverage]:
+		return self._classes
+
+	@readonly
+	def Modules(self) -> Dict[str, ModuleCoverage]:
+		return self._modules
+
+	@readonly
+	def Packages(self) -> Dict[str, "PackageCoverage"]:
+		return self._packages
 
 	def __getitem__(self, key: str) -> Union["PackageCoverage", ModuleCoverage]:
 		try:

--- a/sphinx_reports/DocCoverage.py
+++ b/sphinx_reports/DocCoverage.py
@@ -115,7 +115,7 @@ class DocCoverage(BaseDirective):
 		except KeyError as ex:
 			raise ReportExtensionError(f"conf.py: {ReportDomain.name}_{self.configPrefix}_packages:{self._packageID}.fail_below: Configuration is missing.") from ex
 		except ValueError as ex:
-			raise ReportExtensionError(f"conf.py: {ReportDomain.name}_{self.configPrefix}_packages:{self._packageID}.fail_below: '{packageConfiguration["fail_below"]}' is not an integer in range 0..100.") from ex
+			raise ReportExtensionError(f"conf.py: {ReportDomain.name}_{self.configPrefix}_packages:{self._packageID}.fail_below: '{packageConfiguration['fail_below']}' is not an integer in range 0..100.") from ex
 
 		if not (0.0 <= self._failBelow <= 100.0):
 			raise ReportExtensionError(

--- a/sphinx_reports/DocCoverage.py
+++ b/sphinx_reports/DocCoverage.py
@@ -32,15 +32,22 @@
 **Report documentation coverage as Sphinx documentation page(s).**
 """
 from pathlib import Path
-from typing  import Dict, Tuple, Any, List, Iterable, Mapping, Generator
+from typing import Dict, Tuple, Any, List, Iterable, Mapping, Generator, TypedDict
 
 from docutils             import nodes
 from pyTooling.Decorators import export
 
-from sphinx_reports.Common                          import ReportExtensionError
-from sphinx_reports.Sphinx                          import strip, LegendPosition, BaseDirective
-from sphinx_reports.DataModel.DocumentationCoverage import PackageCoverage
+from sphinx_reports.Common                          import ReportExtensionError, LegendPosition
+from sphinx_reports.Sphinx                          import strip, BaseDirective
+from sphinx_reports.DataModel.DocumentationCoverage import PackageCoverage, AggregatedCoverage
 from sphinx_reports.Adapter.DocStrCoverage          import Analyzer
+
+
+class package_DictType(TypedDict):
+	name: str
+	directory: str
+	fail_below: int
+	levels: Dict[int, Dict[str, str]]
 
 
 @export
@@ -71,17 +78,17 @@ class DocCoverage(BaseDirective):
 	_levels:      Dict[int, Dict[str, str]]
 	_coverage:    PackageCoverage
 
-	def _CheckOptions(self):
+	def _CheckOptions(self) -> None:
 		# Parse all directive options or use default values
 		self._packageID = self._ParseStringOption("packageid")
 		self._legend = self._ParseLegendOption("legend", LegendPosition.Bottom)
 
-	def _CheckConfiguration(self):
+	def _CheckConfiguration(self) -> None:
 		from sphinx_reports import ReportDomain
 
 		# Check configuration fields and load necessary values
 		try:
-			allPackages = self.config[f"{ReportDomain.name}_{self.configPrefix}_packages"]
+			allPackages: Dict[str, package_DictType] = self.config[f"{ReportDomain.name}_{self.configPrefix}_packages"]
 		except (KeyError, AttributeError) as ex:
 			raise ReportExtensionError(f"Configuration option '{ReportDomain.name}_{self.configPrefix}_packages' is not configured.") from ex
 
@@ -120,7 +127,7 @@ class DocCoverage(BaseDirective):
 			100: {"class": "doccov-below100", "background": "rgba(  0, 200,  82, .2)", "desc": "excellent documented"},
 		}
 
-	def _ConvertToColor(self, currentLevel, configKey):
+	def _ConvertToColor(self, currentLevel: float, configKey: str) -> str:
 		for levelLimit, levelConfig in self._levels.items():
 			if (currentLevel * 100) < levelLimit:
 				return levelConfig[configKey]
@@ -143,11 +150,11 @@ class DocCoverage(BaseDirective):
 		tableBody = nodes.tbody()
 		tableGroup += tableBody
 
-		def sortedValues(d: Mapping) -> Generator[Any, None, None]:
+		def sortedValues(d: Mapping[str, AggregatedCoverage]) -> Generator[AggregatedCoverage, None, None]:
 			for key in sorted(d.keys()):
 				yield d[key]
 
-		def renderlevel(tableBody: nodes.tbody, packageCoverage: PackageCoverage, level: int = 0):
+		def renderlevel(tableBody: nodes.tbody, packageCoverage: PackageCoverage, level: int = 0) -> None:
 			tableBody += nodes.row(
 				"",
 				nodes.entry("", nodes.paragraph(text=f"{' '*level}{packageCoverage.Name} ({packageCoverage.File})")),
@@ -222,7 +229,7 @@ class DocCoverage(BaseDirective):
 
 @export
 class DocStrCoverage(DocCoverage):
-	def run(self):
+	def run(self) -> List[nodes.Node]:
 		self._CheckOptions()
 		self._CheckConfiguration()
 

--- a/sphinx_reports/DocCoverage.py
+++ b/sphinx_reports/DocCoverage.py
@@ -180,7 +180,7 @@ class DocCoverage(BaseDirective):
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Expected}")),
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Covered}")),
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Uncovered}")),
-				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Coverage:.1%}")),
+				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Coverage:.0%}")),
 				classes=["doccov-table-row", self._ConvertToColor(packageCoverage.Coverage, "class")],
 				# style="background: rgba(  0, 200,  82, .2);"
 			)
@@ -195,7 +195,7 @@ class DocCoverage(BaseDirective):
 					nodes.entry("", nodes.paragraph(text=f"{module.Expected}")),
 					nodes.entry("", nodes.paragraph(text=f"{module.Covered}")),
 					nodes.entry("", nodes.paragraph(text=f"{module.Uncovered}")),
-					nodes.entry("", nodes.paragraph(text=f"{module.Coverage :.1%}")),
+					nodes.entry("", nodes.paragraph(text=f"{module.Coverage :.0%}")),
 					classes=["doccov-table-row", self._ConvertToColor(module.Coverage, "class")],
 					# style="background: rgba(  0, 200,  82, .2);"
 				)
@@ -209,7 +209,7 @@ class DocCoverage(BaseDirective):
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Expected}")),
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Covered}")),
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Uncovered}")),
-			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Coverage:.1%}"),
+			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Coverage:.0%}"),
 				# classes=[self._ConvertToColor(self._coverage.coverage(), "class")]
 			),
 			classes=["doccov-summary-row", self._ConvertToColor(self._coverage.AggregatedCoverage, "class")]

--- a/sphinx_reports/DocCoverage.py
+++ b/sphinx_reports/DocCoverage.py
@@ -176,11 +176,11 @@ class DocCoverage(BaseDirective):
 		def renderlevel(tableBody: nodes.tbody, packageCoverage: PackageCoverage, level: int = 0) -> None:
 			tableBody += nodes.row(
 				"",
-				nodes.entry("", nodes.paragraph(text=f"{' '*level}{packageCoverage.Name} ({packageCoverage.File})")),
+				nodes.entry("", nodes.paragraph(text=f"{' '*level}📦{packageCoverage.Name}")),
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Expected}")),
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Covered}")),
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Uncovered}")),
-				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Coverage:.0%}")),
+				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Coverage:.1%}")),
 				classes=["doccov-table-row", self._ConvertToColor(packageCoverage.Coverage, "class")],
 				# style="background: rgba(  0, 200,  82, .2);"
 			)
@@ -191,11 +191,11 @@ class DocCoverage(BaseDirective):
 			for module in sortedValues(packageCoverage._modules):
 				tableBody += nodes.row(
 					"",
-					nodes.entry("", nodes.paragraph(text=f"{' '*level}{module.Name} ({module.File})")),
+					nodes.entry("", nodes.paragraph(text=f"{' '*(level+1)} {module.Name}")),
 					nodes.entry("", nodes.paragraph(text=f"{module.Expected}")),
 					nodes.entry("", nodes.paragraph(text=f"{module.Covered}")),
 					nodes.entry("", nodes.paragraph(text=f"{module.Uncovered}")),
-					nodes.entry("", nodes.paragraph(text=f"{module.Coverage :.0%}")),
+					nodes.entry("", nodes.paragraph(text=f"{module.Coverage :.1%}")),
 					classes=["doccov-table-row", self._ConvertToColor(module.Coverage, "class")],
 					# style="background: rgba(  0, 200,  82, .2);"
 				)
@@ -206,10 +206,10 @@ class DocCoverage(BaseDirective):
 		tableBody += nodes.row(
 			"",
 			nodes.entry("", nodes.paragraph(text=f"Overall ({self._coverage.FileCount} files):")),
-			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Expected}")),
-			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Covered}")),
-			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Uncovered}")),
-			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Coverage:.0%}"),
+			nodes.entry("", nodes.paragraph(text=f"{self._coverage.AggregatedExpected}")),
+			nodes.entry("", nodes.paragraph(text=f"{self._coverage.AggregatedCovered}")),
+			nodes.entry("", nodes.paragraph(text=f"{self._coverage.AggregatedUncovered}")),
+			nodes.entry("", nodes.paragraph(text=f"{self._coverage.AggregatedCoverage:.1%}"),
 				# classes=[self._ConvertToColor(self._coverage.coverage(), "class")]
 			),
 			classes=["doccov-summary-row", self._ConvertToColor(self._coverage.AggregatedCoverage, "class")]

--- a/sphinx_reports/DocCoverage.py
+++ b/sphinx_reports/DocCoverage.py
@@ -124,13 +124,13 @@ class DocCoverage(BaseDirective):
 		for levelLimit, levelConfig in self._levels.items():
 			if (currentLevel * 100) < levelLimit:
 				return levelConfig[configKey]
-		else:
-			return self._levels[100][configKey]
+
+		return self._levels[100][configKey]
 
 	def _GenerateCoverageTable(self) -> nodes.table:
 		# Create a table and table header with 5 columns
 		table, tableGroup = self._PrepareTable(
-			id=self._packageID,
+			identifier=self._packageID,
 			columns={
 				"Filename": 500,
 				"Total": 100,
@@ -191,10 +191,10 @@ class DocCoverage(BaseDirective):
 
 		return table
 
-	def _CreateLegend(self, id: str, classes: Iterable[str]) -> List[nodes.Element]:
+	def _CreateLegend(self, identifier: str, classes: Iterable[str]) -> List[nodes.Element]:
 		rubric = nodes.rubric("", text="Legend")
 
-		table = nodes.table("", id=id, classes=classes)
+		table = nodes.table("", id=identifier, classes=classes)
 
 		tableGroup = nodes.tgroup(cols=2)
 		table += tableGroup
@@ -236,11 +236,11 @@ class DocStrCoverage(DocCoverage):
 		container = nodes.container()
 
 		if LegendPosition.Top in self._legend:
-			container += self._CreateLegend(id="legend1", classes=["doccov-legend"])
+			container += self._CreateLegend(identifier="legend1", classes=["doccov-legend"])
 
 		container += self._GenerateCoverageTable()
 
 		if LegendPosition.Bottom in self._legend:
-			container += self._CreateLegend(id="legend2", classes=["doccov-legend"])
+			container += self._CreateLegend(identifier="legend2", classes=["doccov-legend"])
 
 		return [container]

--- a/sphinx_reports/DocCoverage.py
+++ b/sphinx_reports/DocCoverage.py
@@ -32,7 +32,7 @@
 **Report documentation coverage as Sphinx documentation page(s).**
 """
 from pathlib import Path
-from typing import Dict, Tuple, Any, List, Iterable, Mapping, Generator, TypedDict
+from typing  import Dict, Tuple, Any, List, Iterable, Mapping, Generator, TypedDict
 
 from docutils             import nodes
 from pyTooling.Decorators import export

--- a/sphinx_reports/Sphinx.py
+++ b/sphinx_reports/Sphinx.py
@@ -122,8 +122,8 @@ class BaseDirective(ObjectDescription):
 		except KeyError as ex:
 			raise ReportExtensionError(f"{self.directiveName}::{optionName}: Value '{option}' is not a valid member of 'LegendPosition'.") from ex
 
-	def _PrepareTable(self, columns: Dict[str, int], id: str, classes: List[str]) -> Tuple[nodes.table, nodes.tgroup]:
-		table = nodes.table("", id=id, classes=classes)
+	def _PrepareTable(self, columns: Dict[str, int], identifier: str, classes: List[str]) -> Tuple[nodes.table, nodes.tgroup]:
+		table = nodes.table("", identifier=identifier, classes=classes)
 
 		tableGroup = nodes.tgroup(cols=(len(columns)))
 		table += tableGroup

--- a/sphinx_reports/Sphinx.py
+++ b/sphinx_reports/Sphinx.py
@@ -42,7 +42,7 @@ from sphinx_reports.Common import ReportExtensionError, LegendPosition
 
 
 @export
-def strip(option: str):
+def strip(option: str) -> str:
 	return option.strip().lower()
 
 
@@ -96,7 +96,7 @@ class BaseDirective(ObjectDescription):
 
 	def _ParseStringOption(self, optionName: str, default: Nullable[str] = None, regexp: str = "\\w+") -> str:
 		try:
-			option = self.options[optionName]
+			option: str = self.options[optionName]
 		except KeyError as ex:
 			if default is not None:
 				return default

--- a/sphinx_reports/Unittest.py
+++ b/sphinx_reports/Unittest.py
@@ -122,13 +122,13 @@ class UnittestSummary(BaseDirective):
 		for levelLimit, levelConfig in self._levels.items():
 			if (currentLevel * 100) < levelLimit:
 				return levelConfig[configKey]
-		else:
-			return self._levels[100][configKey]
+
+		return self._levels[100][configKey]
 
 	def _GenerateCoverageTable(self) -> nodes.table:
 		# Create a table and table header with 5 columns
 		table, tableGroup = self._PrepareTable(
-			id=self._packageID,
+			identifier=self._packageID,
 			columns={
 				"Filename": 500,
 				"Total": 100,
@@ -189,10 +189,10 @@ class UnittestSummary(BaseDirective):
 
 		return table
 
-	def _CreateLegend(self, id: str, classes: Iterable[str]) -> List[nodes.Element]:
+	def _CreateLegend(self, identifier: str, classes: Iterable[str]) -> List[nodes.Element]:
 		rubric = nodes.rubric("", text="Legend")
 
-		table = nodes.table("", id=id, classes=classes)
+		table = nodes.table("", id=identifier, classes=classes)
 
 		tableGroup = nodes.tgroup(cols=2)
 		table += tableGroup
@@ -231,11 +231,11 @@ class UnittestSummary(BaseDirective):
 		container = nodes.container()
 
 		if LegendPosition.Top in self._legend:
-			container += self._CreateLegend(id="legend1", classes=["doccov-legend"])
+			container += self._CreateLegend(identifier="legend1", classes=["doccov-legend"])
 
 		container += self._GenerateCoverageTable()
 
 		if LegendPosition.Bottom in self._legend:
-			container += self._CreateLegend(id="legend2", classes=["doccov-legend"])
+			container += self._CreateLegend(identifier="legend2", classes=["doccov-legend"])
 
 		return [container]

--- a/sphinx_reports/Unittest.py
+++ b/sphinx_reports/Unittest.py
@@ -159,7 +159,7 @@ class UnittestSummary(BaseDirective):
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Expected}")),
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Covered}")),
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Uncovered}")),
-				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Coverage:.1%}")),
+				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Coverage:.0%}")),
 				classes=["doccov-table-row", self._ConvertToColor(packageCoverage.Coverage, "class")],
 				# style="background: rgba(  0, 200,  82, .2);"
 			)
@@ -174,7 +174,7 @@ class UnittestSummary(BaseDirective):
 					nodes.entry("", nodes.paragraph(text=f"{module.Expected}")),
 					nodes.entry("", nodes.paragraph(text=f"{module.Covered}")),
 					nodes.entry("", nodes.paragraph(text=f"{module.Uncovered}")),
-					nodes.entry("", nodes.paragraph(text=f"{module.Coverage :.1%}")),
+					nodes.entry("", nodes.paragraph(text=f"{module.Coverage :.0%}")),
 					classes=["doccov-table-row", self._ConvertToColor(module.Coverage, "class")],
 					# style="background: rgba(  0, 200,  82, .2);"
 				)
@@ -188,7 +188,7 @@ class UnittestSummary(BaseDirective):
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Expected}")),
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Covered}")),
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Uncovered}")),
-			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Coverage:.1%}"),
+			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Coverage:.0%}"),
 				# classes=[self._ConvertToColor(self._coverage.coverage(), "class")]
 			),
 			classes=["doccov-summary-row", self._ConvertToColor(self._coverage.AggregatedCoverage, "class")]

--- a/sphinx_reports/Unittest.py
+++ b/sphinx_reports/Unittest.py
@@ -32,15 +32,22 @@
 **Report unit test results as Sphinx documentation page(s).**
 """
 from pathlib import Path
-from typing  import Dict, Tuple, Any, List, Iterable, Mapping, Generator
+from typing import Dict, Tuple, Any, List, Iterable, Mapping, Generator, TypedDict
 
 from docutils             import nodes
 from pyTooling.Decorators import export
 
 from sphinx_reports.Common                          import ReportExtensionError
 from sphinx_reports.Sphinx                          import strip, LegendPosition, BaseDirective
-from sphinx_reports.DataModel.DocumentationCoverage import PackageCoverage
+from sphinx_reports.DataModel.DocumentationCoverage import PackageCoverage, AggregatedCoverage
 from sphinx_reports.Adapter.DocStrCoverage          import Analyzer
+
+
+class package_DictType(TypedDict):
+	name: str
+	directory: str
+	fail_below: int
+	levels: Dict[int, Dict[str, str]]
 
 
 @export
@@ -71,15 +78,15 @@ class UnittestSummary(BaseDirective):
 	_levels:      Dict[int, Dict[str, str]]
 	_coverage:    PackageCoverage
 
-	def _CheckOptions(self):
+	def _CheckOptions(self) -> None:
 		# Parse all directive options or use default values
 		self._packageID = self._ParseStringOption("packageid")
 		self._legend = self._ParseLegendOption("legend", LegendPosition.Bottom)
 
-	def _CheckConfiguration(self):
+	def _CheckConfiguration(self) -> None:
 		# Check configuration fields and load necessary values
 		try:
-			allPackages = self.config[f"{self.configPrefix}_packages"]
+			allPackages: Dict[str, package_DictType] = self.config[f"{self.configPrefix}_packages"]
 		except (KeyError, AttributeError) as ex:
 			raise ReportExtensionError(f"Configuration option '{self.configPrefix}_packages' is not configured.") from ex
 
@@ -118,7 +125,7 @@ class UnittestSummary(BaseDirective):
 			100: {"class": "doccov-below100", "background": "rgba(  0, 200,  82, .2)", "desc": "excellent documented"},
 		}
 
-	def _ConvertToColor(self, currentLevel, configKey):
+	def _ConvertToColor(self, currentLevel: float, configKey: str) -> str:
 		for levelLimit, levelConfig in self._levels.items():
 			if (currentLevel * 100) < levelLimit:
 				return levelConfig[configKey]
@@ -141,11 +148,11 @@ class UnittestSummary(BaseDirective):
 		tableBody = nodes.tbody()
 		tableGroup += tableBody
 
-		def sortedValues(d: Mapping) -> Generator[Any, None, None]:
+		def sortedValues(d: Mapping[str, AggregatedCoverage]) -> Generator[AggregatedCoverage, None, None]:
 			for key in sorted(d.keys()):
 				yield d[key]
 
-		def renderlevel(tableBody: nodes.tbody, packageCoverage: PackageCoverage, level: int = 0):
+		def renderlevel(tableBody: nodes.tbody, packageCoverage: PackageCoverage, level: int = 0) -> None:
 			tableBody += nodes.row(
 				"",
 				nodes.entry("", nodes.paragraph(text=f"{' '*level}{packageCoverage.Name} ({packageCoverage.File})")),
@@ -217,7 +224,7 @@ class UnittestSummary(BaseDirective):
 
 		return [rubric, table]
 
-	def run(self):
+	def run(self) -> List[nodes.Node]:
 		self._CheckOptions()
 		self._CheckConfiguration()
 

--- a/sphinx_reports/Unittest.py
+++ b/sphinx_reports/Unittest.py
@@ -32,7 +32,7 @@
 **Report unit test results as Sphinx documentation page(s).**
 """
 from pathlib import Path
-from typing import Dict, Tuple, Any, List, Iterable, Mapping, Generator, TypedDict
+from typing  import Dict, Tuple, Any, List, Iterable, Mapping, Generator, TypedDict
 
 from docutils             import nodes
 from pyTooling.Decorators import export

--- a/sphinx_reports/Unittest.py
+++ b/sphinx_reports/Unittest.py
@@ -159,7 +159,7 @@ class UnittestSummary(BaseDirective):
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Expected}")),
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Covered}")),
 				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Uncovered}")),
-				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Coverage:.0%}")),
+				nodes.entry("", nodes.paragraph(text=f"{packageCoverage.Coverage:.1%}")),
 				classes=["doccov-table-row", self._ConvertToColor(packageCoverage.Coverage, "class")],
 				# style="background: rgba(  0, 200,  82, .2);"
 			)
@@ -174,7 +174,7 @@ class UnittestSummary(BaseDirective):
 					nodes.entry("", nodes.paragraph(text=f"{module.Expected}")),
 					nodes.entry("", nodes.paragraph(text=f"{module.Covered}")),
 					nodes.entry("", nodes.paragraph(text=f"{module.Uncovered}")),
-					nodes.entry("", nodes.paragraph(text=f"{module.Coverage :.0%}")),
+					nodes.entry("", nodes.paragraph(text=f"{module.Coverage :.1%}")),
 					classes=["doccov-table-row", self._ConvertToColor(module.Coverage, "class")],
 					# style="background: rgba(  0, 200,  82, .2);"
 				)
@@ -188,7 +188,7 @@ class UnittestSummary(BaseDirective):
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Expected}")),
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Covered}")),
 			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Uncovered}")),
-			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Coverage:.0%}"),
+			nodes.entry("", nodes.paragraph(text=f"{self._coverage.Coverage:.1%}"),
 				# classes=[self._ConvertToColor(self._coverage.coverage(), "class")]
 			),
 			classes=["doccov-summary-row", self._ConvertToColor(self._coverage.AggregatedCoverage, "class")]

--- a/sphinx_reports/__init__.py
+++ b/sphinx_reports/__init__.py
@@ -46,7 +46,7 @@ __license__ =   "Apache License, Version 2.0"
 __version__ =   "0.3.0"
 __keywords__ =  ["Python3", "Sphinx", "Extension", "Report", "doc-string", "interrogate"]
 
-from typing import Any, Tuple, Dict, Optional as Nullable
+from typing import Any, Tuple, Dict, Optional as Nullable, TypedDict, List
 
 from docutils import nodes
 from pyTooling.Decorators import export
@@ -85,7 +85,7 @@ class ReportDomain(Domain):
 	name =  "report"  #: The name of this domain
 	label = "rpt"     #: The label of this domain
 
-	dependencies = [
+	dependencies: List[str] = [
 	]  #: A list of other extensions this domain depends on.
 
 	from sphinx_reports.CodeCoverage import CodeCoverage
@@ -103,9 +103,9 @@ class ReportDomain(Domain):
 		# "design":   DesignRole,
 	}  #: A dictionary of all roles in this domain.
 
-	indices = {
+	indices = [
 		# LibraryIndex,
-	}  #: A dictionary of all indices in this domain.
+	]  #: A list of all indices in this domain.
 
 	configValues: Dict[str, Tuple[Any, str, Any]] = {
 		"designs":  ({}, "env", Dict),
@@ -157,8 +157,15 @@ class ReportDomain(Domain):
 		raise NotImplementedError()
 
 
+class setup_ReturnType(TypedDict):
+	version: str
+	env_version: int
+	parallel_read_safe: bool
+	parallel_write_safe: bool
+
+
 @export
-def setup(sphinxApplication: Sphinx):
+def setup(sphinxApplication: Sphinx) -> setup_ReturnType:
 	"""
 	Extension setup function registering the ``report`` domain in Sphinx.
 

--- a/sphinx_reports/__init__.py
+++ b/sphinx_reports/__init__.py
@@ -74,7 +74,7 @@ class ReportDomain(Domain):
 
 	* *None*
 
-  .. rubric:: Configuration variables
+	.. rubric:: Configuration variables
 
 	All configuration variables in :file:`conf.py` are prefixed with ``report_*``:
 

--- a/sphinx_reports/__init__.py
+++ b/sphinx_reports/__init__.py
@@ -43,7 +43,7 @@ __author__ =    "Patrick Lehmann"
 __email__ =     "Paebbels@gmail.com"
 __copyright__ = "2023-2024, Patrick Lehmann"
 __license__ =   "Apache License, Version 2.0"
-__version__ =   "0.2.0"
+__version__ =   "0.3.0"
 __keywords__ =  ["Python3", "Sphinx", "Extension", "Report", "doc-string", "interrogate"]
 
 from typing import Any, Tuple, Dict, Optional as Nullable

--- a/sphinx_reports/static/__init__.py
+++ b/sphinx_reports/static/__init__.py
@@ -28,21 +28,6 @@
 # SPDX-License-Identifier: Apache-2.0                                                                                  #
 # ==================================================================================================================== #
 #
-"""Package installer for 'Write version information for any programming language as source file'."""
-from pathlib             import Path
-from pyTooling.Packaging import DescribePythonPackageHostedOnGitHub
-
-gitHubNamespace =        "pyTooling"
-packageName =            "sphinx_reports"
-packageDirectory =       packageName.replace(".", "/")
-packageInformationFile = Path(f"{packageDirectory}/__init__.py")
-
-DescribePythonPackageHostedOnGitHub(
-	packageName=packageName,
-	description="A Sphinx extension providing coverage details embedded in documentation pages.",
-	gitHubNamespace=gitHubNamespace,
-	sourceFileWithVersion=packageInformationFile,
-	dataFiles={
-		"sphinx_reports": ["static/*.css"]
-	}
-)
+"""
+**Package for static resources.**
+"""

--- a/sphinx_reports/static/sphinx-reports.css
+++ b/sphinx_reports/static/sphinx-reports.css
@@ -1,0 +1,35 @@
+/*
+ * Disable odd/even coloring for docutils tables if it's a coverage table.
+ * Otherwise, the 'nth-child' rule will always override row colors indicating the coverage level.
+ */
+.rst-content table.docutils:not(.field-list) tr:nth-child(2n-1) td {
+	background-color: unset;
+}
+
+/*
+ * Coloring for 0..30, 30..50, 50..80, 80..90, 90.100% coverage
+ */
+/* very good */
+.doccov-below100 {
+	background: rgba(0, 200, 82, .4);
+}
+/* good */
+.doccov-below90 {
+	background: rgba(0, 200, 82, .2);
+}
+/* modest */
+.doccov-below80 {
+	background: rgba(255, 145, 0, .2);
+}
+/* bad */
+.doccov-below50 {
+	background: rgba(255, 82, 82, .2);
+}
+/* very bad */
+.doccov-below30 {
+	background: rgba(101, 31, 255, .2);
+}
+
+.doccov-summary-row {
+	font-weight: bold;
+}

--- a/tests/packages/documented/MyModule.py
+++ b/tests/packages/documented/MyModule.py
@@ -1,0 +1,31 @@
+"""
+Module documentation
+"""
+from pyTooling.Decorators import export
+
+MODULE_VARIABLE = 24  #: ModuleVariable documentation
+
+
+@export
+class ModuleClass:
+	"""
+	ModuleClass documentation
+	"""
+	ClassClassField: str  #: Field documentation
+
+	def __init__(self) -> None:
+		"""Initializer documentation"""
+		pass
+
+	def Method(self) -> None:
+		"""Method documentation"""
+		pass
+
+	def __str__(self) -> str:
+		"""Dunder documentation"""
+		pass
+
+
+class DerivedModuleClass(ModuleClass):
+	"""Derived module class documentation"""
+	pass

--- a/tests/packages/documented/__init__.py
+++ b/tests/packages/documented/__init__.py
@@ -1,0 +1,32 @@
+"""
+Package documentation
+"""
+from pyTooling.Decorators import export
+
+
+PACKAGE_VARIABLE = 24  #: PackageVariable documentation
+
+
+@export
+class PackageClass:
+	"""
+	PackageClass documentation
+	"""
+	PackageClassField: str  #: Field documentation
+
+	def __init__(self) -> None:
+		"""Initializer documentation"""
+		pass
+
+	def Method(self) -> None:
+		"""Method documentation"""
+		pass
+
+	def __str__(self) -> str:
+		"""Dunder documentation"""
+		pass
+
+
+class DerivedPackageClass(PackageClass):
+	"""Derived package class documentation"""
+	pass

--- a/tests/packages/partially/MyModule.py
+++ b/tests/packages/partially/MyModule.py
@@ -1,0 +1,25 @@
+from pyTooling.Decorators import export
+
+MODULE_VARIABLE = 24  #: ModulVariable documentation
+
+
+@export
+class ModuleClass:
+	"""
+	ModuleClass documentation
+	"""
+	ModuleClassField: str
+
+	def __init__(self) -> None:
+		pass
+
+	def Method(self) -> None:
+		"""Method documentation"""
+		pass
+
+	def __str__(self) -> str:
+		pass
+
+
+class DerivedModuleClass(ModuleClass):
+	pass

--- a/tests/packages/partially/__init__.py
+++ b/tests/packages/partially/__init__.py
@@ -1,0 +1,26 @@
+"""
+Package documentation
+"""
+from pyTooling.Decorators import export
+
+PACKAGE_VARIABLE = 24
+
+
+@export
+class PackageClass:
+	PackageClassField: str
+
+	def __init__(self) -> None:
+		pass
+
+	def Method(self) -> None:
+		pass
+
+	def __str__(self) -> str:
+		"""Dunder documentation"""
+		pass
+
+
+class DerivedPackageClass(PackageClass):
+	"""Derived package class documentation"""
+	pass

--- a/tests/packages/undocumented/MyModule.py
+++ b/tests/packages/undocumented/MyModule.py
@@ -1,0 +1,21 @@
+from pyTooling.Decorators import export
+
+MODULE_VARIABLE = 24
+
+
+@export
+class ModuleClass:
+	ModuleClassField: str
+
+	def __init__(self) -> None:
+		pass
+
+	def Method(self) -> None:
+		pass
+
+	def __str__(self) -> str:
+		pass
+
+
+class DerivedModuleClass(ModuleClass):
+	pass

--- a/tests/packages/undocumented/__init__.py
+++ b/tests/packages/undocumented/__init__.py
@@ -1,0 +1,21 @@
+from pyTooling.Decorators import export
+
+PACKAGE_VARIABLE = 24
+
+
+@export
+class PackageClass:
+	PackageClassField: str
+
+	def __init__(self) -> None:
+		pass
+
+	def Method(self) -> None:
+		pass
+
+	def __str__(self) -> str:
+		pass
+
+
+class DerivedPackageClass(PackageClass):
+	pass

--- a/tests/unit/Example.py
+++ b/tests/unit/Example.py
@@ -28,91 +28,28 @@
 # SPDX-License-Identifier: Apache-2.0                                                                                  #
 # ==================================================================================================================== #
 #
-"""
-**A Sphinx extension providing coverage details embedded in documentation pages.**
-"""
-from pathlib import Path
-from typing  import List
+"""Unit tests for the data model."""
+from pathlib  import Path
+from unittest import TestCase
 
-from docstr_coverage                   import analyze, ResultCollection
-from docstr_coverage.result_collection import FileCount
-from pyTooling.Decorators              import export, readonly
+from sphinx_reports.Adapter.DocStrCoverage import Analyzer
+from sphinx_reports.DataModel.DocumentationCoverage import ClassCoverage, ModuleCoverage, PackageCoverage
 
-from sphinx_reports.Common                          import ReportExtensionError
-from sphinx_reports.DataModel.DocumentationCoverage import ModuleCoverage, PackageCoverage, AggregatedCoverage
-
-
-@export
-class DocStrCoverageError(ReportExtensionError):
-	pass
+if __name__ == "__main__":
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unitest <testcase module>'")
+	exit(1)
 
 
-@export
-class Analyzer:
-	_searchDirectory: Path
-	_packageName:     str
-	_moduleFiles:     List[Path]
-	_coverageReport:  str
+class Undocumented(TestCase):
+	def test_Package(self) -> None:
+		packageName = "undocumented"
+		packageDirectory = Path(f"tests/packages/{packageName}")
 
-	def __init__(self, directory: Path, packageName: str) -> None:
-		self._searchDirectory = directory
-		self._packageName = packageName
-		self._moduleFiles = []
+		analyzer = Analyzer(packageDirectory, packageName)
+		analyzer.Analyze()
+		coverage = analyzer.Convert()
+		# coverage.CalculateCoverage()
+		coverage.Aggregate()
 
-		if directory.exists():
-			self._moduleFiles.extend(directory.glob("**/*.py"))
-		else:
-			raise DocStrCoverageError(f"Package source directory '{directory}' does not exist.") \
-				from FileNotFoundError(directory)
-
-	@readonly
-	def SearchDirectories(self) -> Path:
-		return self._searchDirectory
-
-	@readonly
-	def PackageName(self) -> str:
-		return self._packageName
-
-	@readonly
-	def ModuleFiles(self) -> List[Path]:
-		return self._moduleFiles
-
-	@readonly
-	def CoverageReport(self) -> ResultCollection:
-		return self._coverageReport
-
-	def Analyze(self) -> ResultCollection:
-		self._coverageReport: ResultCollection = analyze(self._moduleFiles)
-		return self._coverageReport
-
-	def Convert(self) -> PackageCoverage:
-		rootPackageCoverage = PackageCoverage(self._searchDirectory / "__init__.py", self._packageName)
-
-		for key, value in self._coverageReport.files():
-			path: Path = key.relative_to(self._searchDirectory)
-			perFileResult: FileCount = value.count_aggregate()
-
-			moduleName = path.stem
-			modulePath = [p.name for p in path.parents]
-
-			currentCoverageObject: AggregatedCoverage = rootPackageCoverage
-			for packageName in modulePath[1:]:
-				try:
-					currentCoverageObject = currentCoverageObject[packageName]
-				except KeyError:
-					currentCoverageObject = PackageCoverage(path, packageName, currentCoverageObject)
-
-			if moduleName != "__init__":
-				currentCoverageObject = ModuleCoverage(path, moduleName, currentCoverageObject)
-
-			currentCoverageObject._expected = perFileResult.needed
-			currentCoverageObject._covered = perFileResult.found
-			currentCoverageObject._uncovered = perFileResult.missing
-
-			currentCoverageObject._uncovered = currentCoverageObject._expected - currentCoverageObject._covered
-			if currentCoverageObject._expected != 0:
-				currentCoverageObject._coverage = currentCoverageObject._covered / currentCoverageObject._expected
-			else:
-				currentCoverageObject._coverage = 1.0
-
-		return rootPackageCoverage
+		cov = coverage.Coverage


### PR DESCRIPTION
# New Features
* Ship style sheet (CSS) as package resource and copy CSS file to HTML output directory.
  * Added new subpackage `sphinx_reports.static` for resource files.
* Implemented readonly properties for class-internal fields.

# Changes
* Removed Python 3.8 support, because `importlib.resources.files` was introduced with Python 3.9.
* Improved issues reported by mypy.
  * Added `TypedDict`s to handle configuration values from `conf.py`.
  * Added and corrected type hints.
* Improved issues reported by codacy.
  * Renamed paramter `id` to `identifier`, because `id` is a builtin function.
  * Removed some duplicate code.
  * Also adjusted some stupid rules in codacy.
* Read coverage level coloring from `conf.py`.
* Adjusted package classifiers.

# Bug Fixes
* Fixed percentages.
* Fixed reconstruction of package and module hierarchy.

# Documentation
* Added 3 examples of an undocumented, partially documented and fully documented package.
* Fixed footnote.