### PR TITLE
v0.7.2

### DIFF
--- a/doc/Doc-License.rst
+++ b/doc/Doc-License.rst
@@ -17,7 +17,7 @@ licensed under their terms and conditions, or any related information. Creative
 Commons disclaims all liability for damages resulting from their use to the
 fullest extent possible.
 
-.. rubric:: Using Creative Commons Public Licenses
+.. topic:: Using Creative Commons Public Licenses
 
    Creative Commons public licenses provide a standard set of terms and conditions
    that creators and other rights holders may use to share original works of

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,7 +6,7 @@ setuptools ~= 75.1
 pyTooling ~= 6.7
 
 # Enforce latest version on ReadTheDocs
-sphinx ~= 8.0, <8.1
+sphinx ~= 8.1
 docutils ~= 0.21
 
 # ReadTheDocs Theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyTooling ~= 6.7
-pyEDAA.Reports ~= 0.12.1
+pyEDAA.Reports ~= 0.13
 
-sphinx ~= 8.0, <8.1
+sphinx ~= 8.0
 docutils ~= 0.21
 
 Coverage ~= 7.6

--- a/run.ps1
+++ b/run.ps1
@@ -97,7 +97,7 @@ if ($install)
   { Write-Host -ForegroundColor Cyan     "[ADMIN][UNINSTALL] Uninstalling $PackageName ..."
     py -3.12 -m pip uninstall -y $PackageName
     Write-Host -ForegroundColor Cyan     "[ADMIN][INSTALL]   Installing $PackageName from wheel ..."
-    py -3.12 -m pip install .\dist\$PackageName-0.7.1-py3-none-any.whl
+    py -3.12 -m pip install .\dist\$PackageName-0.8.0-py3-none-any.whl
 
     Write-Host -ForegroundColor Cyan     "[ADMIN][INSTALL]   Closing window in 5 seconds ..."
     Start-Sleep -Seconds 5

--- a/sphinx_reports/DocCoverage.py
+++ b/sphinx_reports/DocCoverage.py
@@ -330,7 +330,13 @@ class DocCoverage(DocCoverageBase):
 @export
 class DocStrCoverage(DocCoverage):
 	def run(self) -> List[nodes.Node]:
-		self._CheckOptions()
+		container = nodes.container()
+
+		try:
+			self._CheckOptions()
+		except ReportExtensionError as ex:
+			message = f"Caught {ex.__class__.__name__} when checking options for directive '{self.directiveName}'."
+			return self._internalError(container, __name__, message, ex)
 
 		# Assemble a list of Python source files
 		docStrCov = DocStrCovAnalyzer(self._packageName, self._directory)
@@ -339,7 +345,6 @@ class DocStrCoverage(DocCoverage):
 		# self._coverage.CalculateCoverage()
 		self._coverage.Aggregate()
 
-		container = nodes.container()
 		container += self._GenerateCoverageTable()
 
 		return [container]
@@ -414,9 +419,14 @@ class DocCoverageLegend(DocCoverageBase):
 		return table
 
 	def run(self) -> List[nodes.Node]:
-		self._CheckOptions()
-
 		container = nodes.container()
+
+		try:
+			self._CheckOptions()
+		except ReportExtensionError as ex:
+			message = f"Caught {ex.__class__.__name__} when checking options for directive '{self.directiveName}'."
+			return self._internalError(container, __name__, message, ex)
+
 		if LegendStyle.Table in self._style:
 			if LegendStyle.Horizontal in self._style:
 				container += self._CreateHorizontalLegendTable(identifier=f"{self._packageID}-legend", classes=["report-doccov-legend"])

--- a/sphinx_reports/Sphinx.py
+++ b/sphinx_reports/Sphinx.py
@@ -37,6 +37,7 @@ from typing import Optional as Nullable, Tuple, List
 from docutils              import nodes
 from sphinx.directives     import ObjectDescription
 from pyTooling.Decorators  import export
+from sphinx.util.logging   import getLogger
 
 from sphinx_reports.Common import ReportExtensionError, LegendStyle
 
@@ -174,3 +175,11 @@ class BaseDirective(ObjectDescription):
 			tableHeader += tableRow
 
 		return table, tableGroup
+
+	def _internalError(self, container: nodes.container, location: str, message: str, exception: Exception) -> List[nodes.Node]:
+		logger = getLogger(location)
+		logger.error(f"{message}\n  {exception}")
+
+		container += nodes.paragraph(text=message)
+
+		return [container]

--- a/sphinx_reports/__init__.py
+++ b/sphinx_reports/__init__.py
@@ -59,6 +59,9 @@ from sphinx.domains        import Domain
 from sphinx.environment    import BuildEnvironment
 from pyTooling.Decorators  import export
 from pyTooling.Common      import readResourceFile
+from sphinx.util.logging import getLogger
+
+from sphinx_reports.Common import ReportExtensionError
 
 from sphinx_reports import static as ResourcePackage
 
@@ -173,9 +176,18 @@ class ReportDomain(Domain):
 		from sphinx_reports.DocCoverage  import DocCoverageBase
 		from sphinx_reports.Unittest     import UnittestSummary
 
-		CodeCoverageBase.CheckConfiguration(sphinxApplication, config)
-		DocCoverageBase.CheckConfiguration(sphinxApplication, config)
-		UnittestSummary.CheckConfiguration(sphinxApplication, config)
+		checkConfigurations = (
+			CodeCoverageBase.CheckConfiguration,
+			DocCoverageBase.CheckConfiguration,
+			UnittestSummary.CheckConfiguration,
+		)
+
+		for checkConfiguration in checkConfigurations:
+			try:
+				checkConfiguration(sphinxApplication, config)
+			except ReportExtensionError as ex:
+				logger = getLogger(__name__)
+				logger.error(f"Caught {ex.__class__.__name__} when checking configuration variables.\n  {ex}")
 
 	@staticmethod
 	def AddCSSFiles(sphinxApplication: Sphinx) -> None:

--- a/sphinx_reports/__init__.py
+++ b/sphinx_reports/__init__.py
@@ -43,7 +43,7 @@ __author__ =    "Patrick Lehmann"
 __email__ =     "Paebbels@gmail.com"
 __copyright__ = "2023-2024, Patrick Lehmann"
 __license__ =   "Apache License, Version 2.0"
-__version__ =   "0.7.1"
+__version__ =   "0.7.2"
 __keywords__ =  ["Python3", "Sphinx", "Extension", "Report", "doc-string", "interrogate"]
 
 from hashlib               import md5


### PR DESCRIPTION
Allow all Sphinx 8.x versions.

This was restricted due to sphinxcontrib-mermaid: mgaitan/sphinxcontrib-mermaid#160

# Changes

* Bumped dependencies.

# Bug Fixes

* Added error handling for variable checks from `conf.py`.
* Added error handling for missing / empty fields due to missing or invalid configuration settings from `conf.py`.

# Documentation

Fixed usage of `topic` vs. `rubric`.